### PR TITLE
Change structures of comments/reactions

### DIFF
--- a/src/constants/example-posts.ts
+++ b/src/constants/example-posts.ts
@@ -25,11 +25,10 @@ export const examplePosts: readonly Posts[] = [
 				],
 			},
 		],
-		comments: [],
-		reactions: [
+		comments: [
 			...new Array(100).fill('').map((_, i) => ({
 				id: `i-${i}`,
-				content: '👍',
+				options: [{ key: 'reaction', value: '👍' }],
 				created_by: ZeroAddress,
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
@@ -68,11 +67,9 @@ export const examplePosts: readonly Posts[] = [
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
 			},
-		],
-		reactions: [
 			...new Array(20).fill('').map((_, i) => ({
 				id: `i-${i}`,
-				content: '👍',
+				options: [{ key: 'reaction', value: '👍' }],
 				created_by: ZeroAddress,
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
@@ -103,11 +100,9 @@ export const examplePosts: readonly Posts[] = [
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
 			},
-		],
-		reactions: [
 			...new Array(10).fill('').map((_, i) => ({
 				id: `i-${i}`,
-				content: '👍',
+				options: [{ key: 'reaction', value: '👍' }],
 				created_by: ZeroAddress,
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
@@ -135,11 +130,9 @@ export const examplePosts: readonly Posts[] = [
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
 			},
-		],
-		reactions: [
 			...new Array(80).fill('').map((_, i) => ({
 				id: `i-${i}`,
-				content: '👍',
+				options: [{ key: 'reaction', value: '👍' }],
 				created_by: ZeroAddress,
 				created_at: new Date('2021-01-01T01:34:56Z'),
 				updated_at: new Date('2021-01-01T01:34:56Z'),
@@ -170,6 +163,5 @@ export const examplePosts: readonly Posts[] = [
 				updated_at: new Date('2021-01-01T01:34:56Z'),
 			},
 		],
-		reactions: [],
 	},
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export type Posts = PostPrimitives & {
 	readonly created_at: Date
 	readonly updated_at: Date
 	readonly comments: readonly Comment[]
-	readonly reactions: readonly Reaction[]
 }
 
 export type PostOption = {
@@ -27,17 +26,14 @@ export type PostOption = {
 	readonly value: ClubsGeneralUnit
 }
 
-export type ChildContent = {
+export type Comment = {
 	readonly id: string
-	readonly content: string
+	readonly content?: string
 	readonly created_by: string
 	readonly created_at: Date
 	readonly updated_at: Date
+	readonly options?: readonly PostOption[]
 }
-
-export type Comment = ChildContent
-
-export type Reaction = ChildContent
 
 export type OptionsDatabase = {
 	readonly key: 'database'


### PR DESCRIPTION
Reactions are now part of comments.

Why:
- The interface of comments and reactions is exactly the same.
- Non-authenticated users can see reactions but not the content of comments. This spec can be easily implemented by emptying the `content` of all comments. 