### PR TITLE
Supports plugins mechanism

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 /**/*.vue
+plugin-helper.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ typings/
 
 # Rollup output
 dist
+plugin-helper.d.ts
 
 # Azure Functions artifacts
 bin

--- a/package.json
+++ b/package.json
@@ -6,15 +6,21 @@
 	"main": "dist/index.js",
 	"exports": {
 		".": {
-			"default": "./dist/index.js"
+			"default": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		},
+		"./plugin-helper": {
+			"default": "./dist/plugin-helper/index.js",
+			"types": "./dist/plugin-helper/index.d.ts"
 		}
 	},
-	"types": "./dist/src/index.d.ts",
+	"types": "./dist/index.d.ts",
 	"files": [
 		"dist/**/*.d.ts",
 		"dist/**/*.js",
 		"!**/*.test.*",
-		"src"
+		"src",
+		"plugin-helper.d.ts"
 	],
 	"keywords": [
 		"clubs-plugin"
@@ -80,6 +86,7 @@
 		"prettier-plugin-tailwindcss": "^0.5.5",
 		"rimraf": "5.0.5",
 		"rollup": "3.29.4",
+		"rollup-plugin-dts": "^6.0.2",
 		"svelte": "^4.2.1",
 		"tailwindcss": "3.3.3",
 		"txtgen": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts",
-	"version": "0.4.1",
+	"version": "0.5.0-alpha.0",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 		"ramda": "0.29.0",
 		"redis": "^4.6.7",
 		"sass": "1.68.0",
-		"svelte": "^4.0.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
@@ -80,6 +79,7 @@
 		"prettier-plugin-svelte": "^3.0.0",
 		"rimraf": "5.0.5",
 		"rollup": "3.29.4",
+		"svelte": "^4.2.1",
 		"tailwindcss": "3.3.3",
 		"txtgen": "^3.0.6",
 		"typescript": "5.2.2",

--- a/preview/config.ts
+++ b/preview/config.ts
@@ -46,6 +46,10 @@ export default () =>
 				options: [],
 			},
 			{
+				id: 'example-plugin',
+				options: [],
+			},
+			{
 				id: 'devprotocol:clubs:plugin:posts',
 				options: [
 					{

--- a/preview/plugins.ts
+++ b/preview/plugins.ts
@@ -1,9 +1,11 @@
 import theme from './src/theme'
-import sTokensViewer from '../src/index'
+import plugin from './src/plugin'
+import posts from '../src/index'
 import type { ClubsPlugins } from '@devprotocol/clubs-core'
 
 export default [
 	theme,
-	sTokensViewer,
+	plugin,
+	posts,
 	{ meta: { id: 'devprotocol:clubs:simple-memberships' } },
 ] as ClubsPlugins

--- a/preview/src/plugin/edit:after:content-form.astro
+++ b/preview/src/plugin/edit:after:content-form.astro
@@ -1,0 +1,5 @@
+---
+import Component from './edit:after:content-form.svelte'
+---
+
+<Component client:load />

--- a/preview/src/plugin/edit:after:content-form.svelte
+++ b/preview/src/plugin/edit:after:content-form.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte'
 	import { onUpdate } from '../../../src/plugin-helper'
 
 	onUpdate((post) => {
@@ -11,9 +10,6 @@
 				{ key: 'x', value: 'this option was added by example-plugin.' },
 			],
 		}
-	})
-	onMount(async () => {
-		console.log('MOUNTED')
 	})
 </script>
 

--- a/preview/src/plugin/feed:after:post-content.astro
+++ b/preview/src/plugin/feed:after:post-content.astro
@@ -1,0 +1,5 @@
+---
+import Component from './feed:after:post-content.svelte'
+---
+
+<Component client:load />

--- a/preview/src/plugin/feed:after:post-content.svelte
+++ b/preview/src/plugin/feed:after:post-content.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import { currentPost } from '../../../src/plugin-helper'
+	import type { Posts } from '../../../src'
+
+	let self: HTMLElement
+	let post: Posts | undefined
+
+	onMount(() => {
+		currentPost((data) => {
+			console.log('* currentPost', data)
+			post = data
+		}, self)
+	})
+</script>
+
+<div bind:this={self} class="rounded bg-black/10 p-2">
+	example-plugin added this slot: <b>post id</b> = {post?.id}, <b>masked</b> = {post?.masked}
+</div>

--- a/preview/src/plugin/index.astro
+++ b/preview/src/plugin/index.astro
@@ -1,0 +1,5 @@
+---
+import Component from './index.svelte'
+---
+
+<Component client:load />

--- a/preview/src/plugin/index.astro
+++ b/preview/src/plugin/index.astro
@@ -1,5 +1,0 @@
----
-import Component from './index.svelte'
----
-
-<Component client:load />

--- a/preview/src/plugin/index.svelte
+++ b/preview/src/plugin/index.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import { onUpdate } from '../../../src/plugin-helper'
+
+	onUpdate((post) => {
+		console.log('***', post)
+		return {
+			...post,
+			options: [
+				...post.options.filter((o) => o.key !== 'x'),
+				{ key: 'x', value: 'this option was added by example-plugin.' },
+			],
+		}
+	})
+	onMount(async () => {
+		console.log('MOUNTED')
+	})
+</script>
+
+<div class="rounded bg-black/10 p-2">example-plugin added this slot</div>

--- a/preview/src/plugin/index.ts
+++ b/preview/src/plugin/index.ts
@@ -1,0 +1,26 @@
+import {
+	type ClubsFunctionThemePlugin,
+	ClubsPluginCategory,
+	type ClubsPluginMeta,
+	type ClubsFunctionGetSlots,
+} from '@devprotocol/clubs-core'
+import Component from './index.astro'
+import { SlotName } from '../../../src'
+
+export const getSlots: ClubsFunctionGetSlots = async () => [
+	{
+		slot: SlotName.PostsEditAfterContentForm,
+		component: Component,
+	},
+]
+
+export const meta: ClubsPluginMeta = {
+	id: 'example-plugin',
+	displayName: 'Example plugin',
+	category: ClubsPluginCategory.Uncategorized,
+}
+
+export default {
+	getSlots,
+	meta,
+} as ClubsFunctionThemePlugin

--- a/preview/src/plugin/index.ts
+++ b/preview/src/plugin/index.ts
@@ -4,13 +4,18 @@ import {
 	type ClubsPluginMeta,
 	type ClubsFunctionGetSlots,
 } from '@devprotocol/clubs-core'
-import Component from './index.astro'
+import AfterContentForm from './edit:after:content-form.astro'
+import AfterPostContent from './feed:after:post-content.astro'
 import { SlotName } from '../../../src'
 
 export const getSlots: ClubsFunctionGetSlots = async () => [
 	{
 		slot: SlotName.PostsEditAfterContentForm,
-		component: Component,
+		component: AfterContentForm,
+	},
+	{
+		slot: SlotName.PostsFeedAfterPostContent,
+		component: AfterPostContent,
 	},
 ]
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,9 @@
 import { dirname, relative, resolve } from 'path'
 import typescript from '@rollup/plugin-typescript'
+import { dts } from 'rollup-plugin-dts'
 
 const dir = 'dist'
+const dirPluginHelper = 'dist/plugin-helper'
 
 const useSrc = ({ dir: _dir, ext } = {}) => ({
 	name: 'local:useSrc',
@@ -44,5 +46,39 @@ export default [
 				dir,
 			}),
 		],
+	},
+	{
+		input: 'src/plugin-helper/index.ts',
+		output: [
+			{
+				dir: dirPluginHelper,
+				format: 'es',
+			},
+		],
+		plugins: [typescript({ compilerOptions: { outDir: dirPluginHelper } })],
+	},
+	{
+		input: 'dist/src/index.d.ts',
+		output: [
+			{
+				file: 'dist/index.d.ts',
+				format: 'es',
+			},
+		],
+		plugins: [dts()],
+	},
+	{
+		input: 'dist/plugin-helper/src/plugin-helper/index.d.ts',
+		output: [
+			{
+				file: 'dist/plugin-helper/index.d.ts',
+				format: 'es',
+			},
+			{
+				file: 'plugin-helper.d.ts',
+				format: 'es',
+			},
+		],
+		plugins: [dts()],
 	},
 ]

--- a/src/components/Common/EncodedPostData.vue
+++ b/src/components/Common/EncodedPostData.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { computed, onMounted, ref } from 'vue'
+import type { Posts } from '../../types'
+import { encode } from '@devprotocol/clubs-core'
+import { EncodedPostClassName } from '../../plugin-helper'
+
+const props = defineProps<{ post: Posts }>()
+const encodedPost = computed<string>(() => encode(props.post))
+const input = ref<HTMLElement>()
+const event = (post: Posts) =>
+	new CustomEvent('post-data:props-updated', {
+		detail: { post },
+		cancelable: true,
+	})
+const emit = (post: Posts) => input.value?.dispatchEvent(event(post))
+
+onMounted(() => {
+	emit(props.post)
+})
+</script>
+
+<template>
+	<input
+		ref="input"
+		type="hidden"
+		:value="encodedPost"
+		:class="EncodedPostClassName"
+	/>
+</template>

--- a/src/components/Common/Profile.vue
+++ b/src/components/Common/Profile.vue
@@ -45,7 +45,7 @@ const fetchProfile = async (address: string) => {
 </script>
 
 <template>
-	<div class="flex w-8/12 items-center">
+	<div class="mb-2 flex w-8/12 items-center">
 		<template v-if="avatar">
 			<div
 				class="mr-3 h-12 w-12 rounded-full bg-cover bg-center bg-no-repeat"

--- a/src/components/Page/Contents/Contents.vue
+++ b/src/components/Page/Contents/Contents.vue
@@ -44,13 +44,15 @@ marked.use({ renderer })
 		:title="props.title"
 	/>
 
-	<Mask v-if="props.masked" :memberships="props.memberships" />
-
 	<div
-		v-else
-		class="mb-5 text-3xl font-bold text-black"
+		v-if="!props.masked"
+		class="mb-2 text-3xl font-bold text-black"
 		v-html="content || ''"
 	></div>
+
+	<slot name="after-post-content" />
+
+	<Mask v-if="props.masked" :memberships="props.memberships" />
 </template>
 
 <style scoped></style>

--- a/src/components/Page/Contents/ContentsHead.vue
+++ b/src/components/Page/Contents/ContentsHead.vue
@@ -13,13 +13,13 @@ const { date, address, feedId, title } = defineProps<Props>()
 </script>
 
 <template>
-	<div class="mb-3 flex items-center justify-between">
+	<div class="flex items-center justify-between">
 		<Profile :address="address" :feedId="feedId" />
 		<p class="text-center text-xs text-gray-400 lg:text-base">
 			{{ dayjs(date).format('DD MMM HH:mm') }}
 		</p>
 	</div>
-	<div v-if="title" class="mb-3 text-3xl font-bold text-black">
+	<div v-if="title" class="text-3xl font-bold text-black">
 		{{ title }}
 	</div>
 </template>

--- a/src/components/Page/Contents/Mask.vue
+++ b/src/components/Page/Contents/Mask.vue
@@ -12,7 +12,7 @@ const { memberships } = props
 </script>
 
 <template>
-	<div class="bg-mask mb-2 flex flex-col justify-center rounded-xl p-4">
+	<div class="bg-mask flex flex-col justify-center rounded-xl p-4">
 		<p class="mb-4 text-center text-white sm:mb-4">
 			Unlock this post by becoming a member.
 		</p>

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -129,7 +129,9 @@ const handlePostSuccess = (post: Posts) => {
 				:address="walletAddress"
 				:memberships="props.memberships"
 				@post:success="handlePostSuccess"
-			/>
+			>
+				<slot name="edit:after:content-form" slot="after:content-form"></slot>
+			</Post>
 		</section>
 
 		<!-- Loading -->

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -14,6 +14,7 @@ import { type ContractRunner, hashMessage, type Signer } from 'ethers'
 import { whenDefined, type UndefinedOr } from '@devprotocol/util-ts'
 import { emojiAllowList } from '../../constants'
 import { clientsProperty } from '@devprotocol/dev-kit'
+import EncodedPostData from '../../components/Common/EncodedPostData.vue'
 
 type Props = {
 	options: Option[]
@@ -180,7 +181,7 @@ const handlePostSuccess = (post: Posts) => {
 			v-if="posts.length > 0"
 			v-for="(post, key) in posts"
 			:key="post.id"
-			class="mb-5 rounded bg-white p-5 shadow"
+			class="mb-5 grid gap-3 rounded bg-white p-5 shadow"
 		>
 			<Contents
 				:feedId="props.feedId"
@@ -190,7 +191,11 @@ const handlePostSuccess = (post: Posts) => {
 				:masked="post.masked ?? false"
 				:memberships="props.memberships ?? []"
 				:title="post.title"
-			/>
+			>
+				<template v-slot:after-post-content>
+					<slot name="feed:after:post-content" />
+				</template>
+			</Contents>
 			<Media
 				v-if="!post?.masked"
 				:images="post.options.find((item) => item.key === '#images')"
@@ -202,13 +207,15 @@ const handlePostSuccess = (post: Posts) => {
 				:post-id="post.id"
 				:emoji-allow-list="emojiAllowList"
 			/>
-			<Line v-if="!post?.masked" class="my-5" />
+			<Line v-if="!post?.masked" class="my-2" />
 			<Comment
 				v-if="!post?.masked"
 				:feedId="props.feedId"
 				:postId="post.id"
 				:comments="post.comments"
 			/>
+
+			<EncodedPostData :post="post" />
 		</article>
 	</div>
 </template>

--- a/src/components/Page/Posts/Comment.vue
+++ b/src/components/Page/Posts/Comment.vue
@@ -2,7 +2,6 @@
 import dayjs from 'dayjs'
 import { encode } from '@devprotocol/clubs-core'
 import { ref } from 'vue'
-import { connection } from '@devprotocol/clubs-core/connection'
 import Profile from '../../Common/Profile.vue'
 import type { Comment, CommentPrimitives } from '../../../types'
 import IconSend from '../../../assets/images/icon-send.svg'
@@ -22,7 +21,9 @@ const comments = ref<readonly Comment[]>(props.comments)
 const postComment = async () => {
 	isCommenting.value = true
 
-	const signer = connection().signer.value
+	const signer = (
+		await import('@devprotocol/clubs-core/connection')
+	).connection().signer.value
 	if (!signer) {
 		// TODO: add state for failure.
 		isCommenting.value = false

--- a/src/components/Page/Posts/Media.vue
+++ b/src/components/Page/Posts/Media.vue
@@ -15,7 +15,7 @@ const props = defineProps<Props>()
 </script>
 
 <template>
-	<div class="mb-5 flex flex-wrap gap-x-1 gap-y-1">
+	<div class="mb-2 flex flex-wrap gap-x-1 gap-y-1">
 		<div
 			v-if="props.required"
 			class="overflow-hidden bg-gray-100"

--- a/src/components/Page/Posts/Post.vue
+++ b/src/components/Page/Posts/Post.vue
@@ -1,11 +1,12 @@
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import Line from '../../Common/Line.vue'
 import AddMedia from './Post/AddMedia.vue'
 import DoPost from './Post/DoPost.vue'
 import Images from './Media/Images.vue'
-import type { Membership, Posts } from '../../../types'
+import type { Membership, PostPrimitives, Posts } from '../../../types'
 import Profile from '../../Common/Profile.vue'
+import { update as callUpdate } from '../../../plugin-helper'
 
 type Props = {
 	feedId: string
@@ -21,6 +22,7 @@ const emit = defineEmits<Emits>()
 
 const props = defineProps<Props>()
 
+const postItem = ref<PostPrimitives>()
 const title = ref('')
 const contents = ref('')
 
@@ -63,6 +65,28 @@ const handleUploadImages = (files: string) => {
 	uploadImages.value.push(files)
 }
 
+watch(
+	[title, contents, selectedLimitedAccess],
+	async ([_title, _contents, _selectedLimitedAccess]) => {
+		const post: PostPrimitives = {
+			title: _title,
+			content: _contents,
+			options: [
+				{
+					key: 'require-one-of',
+					value: _selectedLimitedAccess
+						.filter(({ payload }) => payload !== undefined)
+						.map(({ payload }) => payload as Uint8Array),
+				},
+			],
+		}
+		console.log({ post })
+		const newPost = await callUpdate(post)
+		console.log({ newPost })
+		postItem.value = newPost
+	},
+)
+
 // Post Success
 const handlePostSuccess = (data: Posts) => {
 	emit('post:success', data)
@@ -81,128 +105,130 @@ const handleDeleteImageAll = () => {
 }
 </script>
 <template>
-	<div class="mb-3 flex items-center justify-between">
-		<Profile :address="props.address" :feedId="props.feedId" />
-	</div>
-
-	<!-- title -->
-	<div class="text-3xl font-bold text-black">
-		<input
-			v-model="title"
-			class="w-full border-none px-2 py-2 text-gray-700 focus:border-indigo-500 focus:outline-none"
-			type="text"
-			placeholder="Title"
-		/>
-	</div>
-
-	<!-- 入力フォーム -->
-	<div class="mb-5 text-3xl font-bold text-black">
-		<textarea
-			v-model="contents"
-			class="w-full border-none px-2 py-2 text-base text-gray-700 focus:border-indigo-500 focus:outline-none"
-			rows="3"
-			type="text"
-			placeholder="What’s happening?"
-		/>
-	</div>
-
-	<slot name="after:content-form"></slot>
-
-	<!-- /入力フォーム -->
-	<!-- Limited access button -->
-	<div class="relative mb-5 flex items-center">
-		<button
-			class="rounded-3xl border border-transparent bg-blue-600 px-8 py-2 text-base text-white shadow-sm focus:outline-none"
-			@click="onClickLimitedAccess"
-		>
-			<!-- icon-plus.svgを表示 -->
-			<svg
-				class="mr-3 inline h-5 w-5"
-				xmlns="http://www.w3.org/2000/svg"
-				viewBox="0 0 20 20"
-				fill="currentColor"
-			>
-				<path
-					fill-rule="evenodd"
-					d="M10 3a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V4a1 1 0 011-1z"
-					clip-rule="evenodd"
-				/>
-			</svg>
-			Limited access
-		</button>
-		<!-- 選択済みのLimited accessを表示 -->
-		<div class="ml-3 flex items-center gap-3">
-			<span
-				v-for="selectedLimitedAccessType in selectedLimitedAccess"
-				class="inline-flex items-center rounded-full bg-yellow-100 px-3 py-0.5 text-xs font-medium text-yellow-800"
-			>
-				{{ selectedLimitedAccessType.name }}
-			</span>
+	<div class="grid gap-5">
+		<div class="flex items-center justify-between">
+			<Profile :address="props.address" :feedId="props.feedId" />
 		</div>
-		<!-- modal menu -->
-		<ul
-			v-if="openLimitedAccessModal"
-			class="absolute left-0 top-14 z-20 flex flex-col gap-3 rounded-md bg-white p-3 shadow-xl"
-		>
-			<li v-for="limitedAccessType in limitedAccessTypes">
-				<label
-					:for="limitedAccessType.id"
-					class="flex items-center gap-3 text-sm font-medium text-gray-900"
+
+		<!-- title -->
+		<span>
+			<div class="text-3xl font-bold text-black">
+				<input
+					v-model="title"
+					class="w-full border-none px-2 py-2 text-gray-700 focus:border-indigo-500 focus:outline-none"
+					type="text"
+					placeholder="Title"
+				/>
+			</div>
+
+			<!-- 入力フォーム -->
+			<div class="text-3xl font-bold text-black">
+				<textarea
+					v-model="contents"
+					class="w-full border-none px-2 py-2 text-base text-gray-700 focus:border-indigo-500 focus:outline-none"
+					rows="3"
+					type="text"
+					placeholder="What’s happening?"
+				/>
+			</div>
+		</span>
+
+		<slot name="after-content-form"></slot>
+
+		<!-- /入力フォーム -->
+		<!-- Limited access button -->
+		<div class="relative flex items-center">
+			<button
+				class="rounded-3xl border border-transparent bg-blue-600 px-8 py-2 text-base text-white shadow-sm focus:outline-none"
+				@click="onClickLimitedAccess"
+			>
+				<!-- icon-plus.svgを表示 -->
+				<svg
+					class="mr-3 inline h-5 w-5"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 20 20"
+					fill="currentColor"
 				>
-					<input
-						:id="limitedAccessType.id"
-						type="checkbox"
-						class="h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-blue-500"
-						:checked="selectedLimitedAccess.includes(limitedAccessType)"
-						@change="onUpdateLimitedAccess(limitedAccessType)"
+					<path
+						fill-rule="evenodd"
+						d="M10 3a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V4a1 1 0 011-1z"
+						clip-rule="evenodd"
 					/>
-					<img
-						class="h-24 w-24 rounded"
-						:src="limitedAccessType.imageSrc"
-						:alt="limitedAccessType.name"
-					/>
-					<div class="flex flex-col">
-						<p class="text-gray-900">{{ limitedAccessType.name }}</p>
-						<p class="text-gray-500">
-							{{ limitedAccessType.price }} {{ limitedAccessType.currency }}
-						</p>
-					</div>
-				</label>
-			</li>
-		</ul>
-		<div
-			v-if="openLimitedAccessModal"
-			class="fixed inset-0 z-10"
-			@click="onCloseLimitedAccess"
-		></div>
-	</div>
-	<!-- /Limited access button -->
-	<!-- Media preview -->
-	<div class="mb-5 flex flex-wrap gap-x-1 gap-y-1">
-		<Images
-			v-if="uploadImages"
-			:images="uploadImages"
-			is-post="true"
-			@delete:image="handleDeletePreviewImage"
-		/>
-	</div>
-	<!-- /Media preview -->
-	<Line class="mb-5" />
-	<!-- アクションエリア -->
-	<div class="flex items-center justify-between">
-		<!-- 画像ボタン -->
-		<AddMedia @upload:image="handleUploadImages" />
-		<!-- /画像ボタン -->
-		<!-- Postボタン -->
-		<DoPost
-			:feedId="props.feedId"
-			:images="uploadImages"
-			:content="contents"
-			:title="title"
-			:selectedLimitedAccess="selectedLimitedAccess"
-			@post:success="handlePostSuccess"
-		/>
-		<!-- /Postボタン -->
+				</svg>
+				Limited access
+			</button>
+			<!-- 選択済みのLimited accessを表示 -->
+			<div class="ml-3 flex items-center gap-3">
+				<span
+					v-for="selectedLimitedAccessType in selectedLimitedAccess"
+					class="inline-flex items-center rounded-full bg-yellow-100 px-3 py-0.5 text-xs font-medium text-yellow-800"
+				>
+					{{ selectedLimitedAccessType.name }}
+				</span>
+			</div>
+			<!-- modal menu -->
+			<ul
+				v-if="openLimitedAccessModal"
+				class="absolute left-0 top-14 z-20 flex flex-col gap-3 rounded-md bg-white p-3 shadow-xl"
+			>
+				<li v-for="limitedAccessType in limitedAccessTypes">
+					<label
+						:for="limitedAccessType.id"
+						class="flex items-center gap-3 text-sm font-medium text-gray-900"
+					>
+						<input
+							:id="limitedAccessType.id"
+							type="checkbox"
+							class="h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-blue-500"
+							:checked="selectedLimitedAccess.includes(limitedAccessType)"
+							@change="onUpdateLimitedAccess(limitedAccessType)"
+						/>
+						<img
+							class="h-24 w-24 rounded"
+							:src="limitedAccessType.imageSrc"
+							:alt="limitedAccessType.name"
+						/>
+						<div class="flex flex-col">
+							<p class="text-gray-900">{{ limitedAccessType.name }}</p>
+							<p class="text-gray-500">
+								{{ limitedAccessType.price }} {{ limitedAccessType.currency }}
+							</p>
+						</div>
+					</label>
+				</li>
+			</ul>
+			<div
+				v-if="openLimitedAccessModal"
+				class="fixed inset-0 z-10"
+				@click="onCloseLimitedAccess"
+			></div>
+		</div>
+		<!-- /Limited access button -->
+		<!-- Media preview -->
+		<div v-if="uploadImages.length" class="flex flex-wrap gap-x-1 gap-y-1">
+			<Images
+				:images="uploadImages"
+				is-post="true"
+				@delete:image="handleDeletePreviewImage"
+			/>
+		</div>
+		<!-- /Media preview -->
+		<Line class="" />
+		<!-- アクションエリア -->
+		<div class="flex items-center justify-between">
+			<!-- 画像ボタン -->
+			<AddMedia @upload:image="handleUploadImages" />
+			<!-- /画像ボタン -->
+			<!-- Postボタン -->
+			<DoPost
+				:feedId="props.feedId"
+				:images="uploadImages"
+				:post="postItem ?? { title: '', content: '', options: [] }"
+				:selectedLimitedAccess="selectedLimitedAccess"
+				@post:success="handlePostSuccess"
+			/>
+			<!-- /Postボタン -->
+		</div>
 	</div>
 	<!-- /アクション -->
 </template>

--- a/src/components/Page/Posts/Post.vue
+++ b/src/components/Page/Posts/Post.vue
@@ -105,6 +105,9 @@ const handleDeleteImageAll = () => {
 			placeholder="What’s happening?"
 		/>
 	</div>
+
+	<slot name="after:content-form"></slot>
+
 	<!-- /入力フォーム -->
 	<!-- Limited access button -->
 	<div class="relative flex items-center mb-5">

--- a/src/components/Page/Posts/Reactions.vue
+++ b/src/components/Page/Posts/Reactions.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import type { Reactions } from '../../../types'
-import { connection } from '@devprotocol/clubs-core/connection'
 import { encode } from '@devprotocol/clubs-core'
 import type { UndefinedOr } from '@devprotocol/util-ts'
 
@@ -25,7 +24,9 @@ const toggleReaction = async (emoji: string) => {
 
 	isTogglingReaction.value = true
 
-	const signer = connection().signer.value
+	const signer = (
+		await import('@devprotocol/clubs-core/connection')
+	).connection().signer.value
 	if (!signer) {
 		// TODO: add state for failure.
 		isTogglingReaction.value = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,3 +425,5 @@ export default {
 	getSlots,
 	meta,
 } as ClubsFunctionPlugin
+
+export * from './types'

--- a/src/pages/Posts.astro
+++ b/src/pages/Posts.astro
@@ -1,14 +1,23 @@
 ---
+import type { ClubsPropsPages } from '@devprotocol/clubs-core'
 import Posts_ from '../components/Page/Index.vue'
 import type { Membership, Option } from '../types'
+import  { PostsSlotName } from '../types'
 
-interface Props {
+interface Props extends ClubsPropsPages {
 	options: Option[]
 	feedId: string
 	propertyAddress: string
 	memberships?: Membership[]
 	adminRolePoints: number
 }
+
+const {options,feedId,propertyAddress,memberships,adminRolePoints,clubs} = Astro.props
+
+const SlotsPostsEditAfterContentForm=clubs.slots.filter(slot=>slot.slot===PostsSlotName.PostsEditAfterContentForm)
 ---
 
-<Posts_ client:only="vue" {...Astro.props} />
+<Posts_ client:only="vue" options={options} feedId={feedId} propertyAddress={propertyAddress} memberships={memberships} adminRolePoints={adminRolePoints}>
+	{SlotsPostsEditAfterContentForm.map(Slot=><Slot.component {...Slot.props} slot="edit:after:content-form"/>)}
+</Posts_>
+

--- a/src/pages/Posts.astro
+++ b/src/pages/Posts.astro
@@ -2,7 +2,7 @@
 import type { ClubsPropsPages } from '@devprotocol/clubs-core'
 import Posts_ from '../components/Page/Index.vue'
 import type { Membership, Option } from '../types'
-import  { PostsSlotName } from '../types'
+import { SlotName } from '../types'
 
 interface Props extends ClubsPropsPages {
 	options: Option[]
@@ -12,12 +12,31 @@ interface Props extends ClubsPropsPages {
 	adminRolePoints: number
 }
 
-const {options,feedId,propertyAddress,memberships,adminRolePoints,clubs} = Astro.props
+const {
+	options,
+	feedId,
+	propertyAddress,
+	memberships,
+	adminRolePoints,
+	clubs,
+} = Astro.props
 
-const SlotsPostsEditAfterContentForm=clubs.slots.filter(slot=>slot.slot===PostsSlotName.PostsEditAfterContentForm)
+const SlotsPostsEditAfterContentForm = clubs.slots.filter(
+	(slot) => slot.slot === SlotName.PostsEditAfterContentForm,
+)
 ---
 
-<Posts_ client:only="vue" options={options} feedId={feedId} propertyAddress={propertyAddress} memberships={memberships} adminRolePoints={adminRolePoints}>
-	{SlotsPostsEditAfterContentForm.map(Slot=><Slot.component {...Slot.props} slot="edit:after:content-form"/>)}
+<Posts_
+	client:load
+	options={options}
+	feedId={feedId}
+	propertyAddress={propertyAddress}
+	memberships={memberships}
+	adminRolePoints={adminRolePoints}
+>
+	{
+		SlotsPostsEditAfterContentForm.map((Slot) => (
+			<Slot.component {...Slot.props} slot="edit:after:content-form" />
+		))
+	}
 </Posts_>
-

--- a/src/pages/Posts.astro
+++ b/src/pages/Posts.astro
@@ -24,6 +24,9 @@ const {
 const SlotsPostsEditAfterContentForm = clubs.slots.filter(
 	(slot) => slot.slot === SlotName.PostsEditAfterContentForm,
 )
+const SlotsPostsFeedAfterPostContent = clubs.slots.filter(
+	(slot) => slot.slot === SlotName.PostsFeedAfterPostContent,
+)
 ---
 
 <Posts_
@@ -37,6 +40,11 @@ const SlotsPostsEditAfterContentForm = clubs.slots.filter(
 	{
 		SlotsPostsEditAfterContentForm.map((Slot) => (
 			<Slot.component {...Slot.props} slot="edit:after:content-form" />
+		))
+	}
+	{
+		SlotsPostsFeedAfterPostContent.map((Slot) => (
+			<Slot.component {...Slot.props} slot="feed:after:post-content" />
 		))
 	}
 </Posts_>

--- a/src/plugin-helper/index.ts
+++ b/src/plugin-helper/index.ts
@@ -1,6 +1,12 @@
+/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
+/* eslint-disable functional/no-expression-statement */
+/* eslint-disable functional/no-let */
+/* eslint-disable functional/no-return-void */
 /* eslint-disable functional/no-loop-statement */
 import { always, tryCatch } from 'ramda'
-import type { PostPrimitives } from '../types'
+import { type PostPrimitives, type Posts } from '../types'
+import { whenDefined, type UndefinedOr } from '@devprotocol/util-ts'
+import { decode } from '@devprotocol/clubs-core'
 
 export type OnUpdateHandler = (
 	post: PostPrimitives,
@@ -17,10 +23,36 @@ export const update = async (
 ): Promise<PostPrimitives> => {
 	// eslint-disable-next-line functional/no-let
 	let post = _post
-	// eslint-disable-next-line functional/no-loop-statement
 	for await (const handler of onUpdateHandlers) {
-		// eslint-disable-next-line functional/no-expression-statement
 		post = await tryCatch(handler, always(post))(post)
 	}
 	return post
+}
+
+export const EncodedPostClassName = '__input-encoded-post__'
+
+export const currentPost = (
+	handler: (post: Posts) => unknown,
+	base: Readonly<Element>,
+) => {
+	let current: UndefinedOr<null | Element> = base
+	let input: UndefinedOr<HTMLInputElement>
+	let count = 0
+	while (count < 30 && !input) {
+		input = current?.getElementsByClassName(
+			EncodedPostClassName,
+		)?.[0] as UndefinedOr<HTMLInputElement>
+		current = current?.parentElement
+		count = count + 1
+	}
+	whenDefined(input, (_input) => {
+		handler(decode<Posts>(_input.value))
+		new MutationObserver((mutationList) => {
+			console.log({ mutationList })
+			mutationList.some(({ attributeName }) => attributeName === 'value') &&
+				handler(decode<Posts>(_input.value))
+		}).observe(_input, { attributes: true })
+		return _input
+	})
+	return input
 }

--- a/src/plugin-helper/index.ts
+++ b/src/plugin-helper/index.ts
@@ -1,0 +1,26 @@
+/* eslint-disable functional/no-loop-statement */
+import { always, tryCatch } from 'ramda'
+import type { PostPrimitives } from '../types'
+
+export type OnUpdateHandler = (
+	post: PostPrimitives,
+) => PostPrimitives | Promise<PostPrimitives>
+
+const onUpdateHandlers = new Set<OnUpdateHandler>()
+
+// eslint-disable-next-line functional/no-return-void
+export const onUpdate = (handler: OnUpdateHandler) =>
+	onUpdateHandlers.add(handler)
+
+export const update = async (
+	_post: PostPrimitives,
+): Promise<PostPrimitives> => {
+	// eslint-disable-next-line functional/no-let
+	let post = _post
+	// eslint-disable-next-line functional/no-loop-statement
+	for await (const handler of onUpdateHandlers) {
+		// eslint-disable-next-line functional/no-expression-statement
+		post = await tryCatch(handler, always(post))(post)
+	}
+	return post
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,6 @@ export type Reactions = {
 	readonly [emoji: string]: readonly string[]
 }
 
-export enum PostsSlotName {
+export enum SlotName {
 	PostsEditAfterContentForm = 'posts:edit:after:content-form',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,4 +74,5 @@ export type Reactions = {
 
 export enum SlotName {
 	PostsEditAfterContentForm = 'posts:edit:after:content-form',
+	PostsFeedAfterPostContent = 'posts:feed:after:post-content',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,3 +71,7 @@ export type Membership = {
 export type Reactions = {
 	readonly [emoji: string]: readonly string[]
 }
+
+export enum PostsSlotName {
+	PostsEditAfterContentForm = 'posts:edit:after:content-form',
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,19 +3,5 @@ import { clubs } from '@devprotocol/clubs-core/tailwind'
 export default {
 	mode: 'jit',
 	presets: [clubs],
-	theme: {
-		extend: {
-			animation: {
-				'c-bash-spinner': 'c-bash-spinner 1s linear infinite',
-			},
-			keyframes: {
-				'c-bash-spinner': {
-					'0%': { content: '"/"' },
-					'33%': { content: '"-"' },
-					'66%': { content: '"\\005C"' },
-					'100%': { content: '"|"' },
-				},
-			},
-		},
-	},
+	content: [...clubs.content, 'preview/src/**/*'],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
 		"declaration": true,
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
-		"importsNotUsedAsValues": "error",
 		"types": ["astro/client"]
 	},
 	"include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,6 +5921,15 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-dts@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-6.0.2.tgz#a32bd89ddca1471e9dcdcbd6dbc91e3a56734570"
+  integrity sha512-GYCCy9DyE5csSuUObktJBpjNpW2iLZMabNDIiAqzQWBl7l/WHzjvtAXevf8Lftk8EA920tuxeB/g8dM8MVMR6A==
+  dependencies:
+    magic-string "^0.30.3"
+  optionalDependencies:
+    "@babel/code-frame" "^7.22.13"
+
 rollup@3.29.4, rollup@^3.27.1:
   version "3.29.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6426,7 +6426,7 @@ svelte2tsx@^0.6.20:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"
 
-svelte@^4.0.0:
+svelte@^4.0.0, svelte@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.2.1.tgz#33d603af4da103a5ad988d7fcc992a87421a1e6e"
   integrity sha512-LpLqY2Jr7cRxkrTc796/AaaoMLF/1ax7cto8Ot76wrvKQhrPmZ0JgajiWPmg9mTSDqO16SSLiD17r9MsvAPTmw==


### PR DESCRIPTION
With this PR, Posts provides an opportunity for third-party plugins to extend the functionality of Posts.

The basis of any plugin is through slots, and currently, it supports two slots. Now Posts exports `SlotName` enum and some plugin helpers. 

## 1. `SlotName.PostsEditAfterContentForm`

PostsEditAfterContentForm slot is inserted immediately after the `<textarea>` of ​​the post form.

### Modifying the composing post

You can import `onUpdate` from `@devprotocol/clubs-plugin-posts/plugin-helper` to modify the post item that will be submitted. Since multiple slots may be inserted, `onUpdate` is called in the order of insertion, and all changes are relayed. The example implementation inserts an option with `key: "x"` into the post item.

https://github.com/dev-protocol/clubs-plugin-posts/blob/6cec21d6d46e0fd796d36b9e7913c6a2b6a19b13/preview/src/plugin/edit:after:content-form.svelte#L1-L16

https://github.com/dev-protocol/clubs-plugin-posts/blob/6cec21d6d46e0fd796d36b9e7913c6a2b6a19b13/preview/src/plugin/index.ts#L12-L15

#### Slotted UI

![Slot UI](https://github.com/dev-protocol/clubs-plugin-posts/assets/1970283/93531dd2-085b-4a8a-9826-7482990b2a45)

#### Logger output (adding `key: "x"` to original data)

![console.log](https://github.com/dev-protocol/clubs-plugin-posts/assets/1970283/7bab7c80-55fd-460e-9605-2ac03e1d2bf7)

## 2. `SlotName.PostsFeedAfterPostContent`

PostsFeedAfterPostContent slot is inserted immediately after the main content area for each post item on the feed.

### Referencing the current post data

You can import `currentPost` from `@devprotocol/clubs-plugin-posts/plugin-helper` to reactively reference the data of the slotted post item. `currentPost` relies on the DOM to access the state across difference UI frameworks, and the component's DOM must be passed as the second argument.

https://github.com/dev-protocol/clubs-plugin-posts/blob/6cec21d6d46e0fd796d36b9e7913c6a2b6a19b13/preview/src/plugin/feed:after:post-content.svelte#L1-L19

https://github.com/dev-protocol/clubs-plugin-posts/blob/6cec21d6d46e0fd796d36b9e7913c6a2b6a19b13/preview/src/plugin/index.ts#L16-L19

#### Slotted UI before updated (masked is true)

![image](https://github.com/dev-protocol/clubs-plugin-posts/assets/1970283/14768198-fd3f-4b0c-8381-b7d3b21c0d5a)

#### Slotted UI after updated (masked is now undefined)

![image](https://github.com/dev-protocol/clubs-plugin-posts/assets/1970283/1f007c25-1436-4f08-a17a-c04ac545e3ca)
