### PR TITLE
Use TAG instead of TEXT for UUIDs

### DIFF
--- a/src/constants/redis.ts
+++ b/src/constants/redis.ts
@@ -23,14 +23,14 @@ export const _raw = {
 
 export const _scope = {
 	'$._scope': {
-		type: SchemaFieldTypes.TEXT,
+		type: SchemaFieldTypes.TAG,
 		AS: '_scope',
 	},
 } satisfies RediSearchSchema
 
 export const _post_id = {
 	'$._post_id': {
-		type: SchemaFieldTypes.TEXT,
+		type: SchemaFieldTypes.TAG,
 		AS: '_post_id',
 	},
 } satisfies RediSearchSchema
@@ -44,14 +44,14 @@ export const _parent_type = {
 
 export const _parent_id = {
 	'$._parent_id': {
-		type: SchemaFieldTypes.TEXT,
+		type: SchemaFieldTypes.TAG,
 		AS: '_parent_id',
 	},
 } satisfies RediSearchSchema
 
 export const id = {
 	'$.id': {
-		type: SchemaFieldTypes.TEXT,
+		type: SchemaFieldTypes.TAG,
 		AS: 'id',
 	},
 } satisfies RediSearchSchema

--- a/src/db/redis-documents.ts
+++ b/src/db/redis-documents.ts
@@ -418,7 +418,7 @@ export const fetchComments = async ({
 	 */
 	const result = await client.ft.search(
 		schema.Index.Comment,
-		`@${schema._post_id['$._post_id'].AS}:${uuidToQuery(postId)}`,
+		`@${schema._post_id['$._post_id'].AS}:{${uuidToQuery(postId)}}`,
 		{
 			LIMIT: {
 				from: start,
@@ -461,7 +461,7 @@ export const fetchAllOptions = async ({
 	 */
 	const query = `@${schema._parent_type['$._parent_type'].AS}:${parentType} @${
 		schema._parent_id['$._parent_id'].AS
-	}:${uuidToQuery(parentId)}`
+	}:{${uuidToQuery(parentId)}}`
 	const loop = async (
 		start: number,
 		list: readonly OptionDocument[],
@@ -507,7 +507,7 @@ export const fetchAllReactions = async ({
 	/**
 	 * Search options where parent id is parentId
 	 */
-	const query = `@${schema._post_id['$._post_id'].AS}:${uuidToQuery(postId)}`
+	const query = `@${schema._post_id['$._post_id'].AS}:{${uuidToQuery(postId)}}`
 	const loop = async (
 		start: number,
 		list: readonly ReactionDocument[],

--- a/src/db/redis.ts
+++ b/src/db/redis.ts
@@ -74,7 +74,7 @@ export const getPaginatedPosts = async ({
 
 	const fetchPosts = await client.ft.search(
 		Index.Post,
-		`@_scope:${uuidToQuery(scope)}`,
+		`@_scope:{${uuidToQuery(scope)}}`,
 		{
 			LIMIT: { from: page, size: limit },
 		},

--- a/src/fixtures/search.ts
+++ b/src/fixtures/search.ts
@@ -1,1 +1,1 @@
-export const uuidToQuery = (id: string) => id.replaceAll('-', '*')
+export const uuidToQuery = (id: string) => id.replaceAll('-', '\\-')


### PR DESCRIPTION
I updated the index schemas because `TAG` is better than `TEXT` for UUIDs.

If your local DB uses old indexes, you need to refresh the indexes.

```bash
# Connect to the redis
redis-cli -u redis://<username>:<password>@redis-XXXXX.XXXX.us-east-X-X.ec2.cloud.redislabs.com:XXXXX
# Drop indexes
FT.DROPINDEX idx::devprotocol:clubs:plugin:posts::post
FT.DROPINDEX idx::devprotocol:clubs:plugin:posts::comment
FT.DROPINDEX idx::devprotocol:clubs:plugin:posts::reaction
FT.DROPINDEX idx::devprotocol:clubs:plugin:posts::option
# Re-index
curl -X POST -H "Content-Type: application/json" http://localhost:3000/api/devprotocol:clubs:plugin:posts/indexing/documents:redis
```