### PR TITLE
Add feedId to Slots components in Posts

### DIFF
--- a/src/pages/Posts.astro
+++ b/src/pages/Posts.astro
@@ -39,12 +39,20 @@ const SlotsPostsFeedAfterPostContent = clubs.slots.filter(
 >
 	{
 		SlotsPostsEditAfterContentForm.map((Slot) => (
-			<Slot.component {...Slot.props} slot="edit:after:content-form" />
+			<Slot.component
+				{...Slot.props}
+				feedId={feedId}
+				slot="edit:after:content-form"
+			/>
 		))
 	}
 	{
 		SlotsPostsFeedAfterPostContent.map((Slot) => (
-			<Slot.component {...Slot.props} slot="feed:after:post-content" />
+			<Slot.component
+				{...Slot.props}
+				feedId={feedId}
+				slot="feed:after:post-content"
+			/>
 		))
 	}
 </Posts_>


### PR DESCRIPTION
This commit adds the feedId as a prop to the SlotsPostsEditAfterContentForm and SlotsPostsFeedAfterPostContent components within the Posts.astro file. This change ensures that these components are linked to the correct feed instance.