### PR TITLE
Use nanoid as a `feed.id`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"dompurify": "^3.0.5",
 		"ethers": "^6.6.4",
 		"marked": "12.0.1",
+		"nanoid": "^5.0.6",
 		"photoswipe": "5.4.3",
 		"ramda": "0.29.1",
 		"redis": "^4.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/src/components/Admin/Feed.vue
+++ b/src/components/Admin/Feed.vue
@@ -3,6 +3,7 @@ import { type PropType, ref } from 'vue'
 import { type ClubsPropsAdminPages, setOptions } from '@devprotocol/clubs-core'
 import type { OptionsDatabase } from '../../types.ts'
 import { uuidFactory } from '../../db/uuidFactory.ts'
+import { nanoid } from 'nanoid'
 
 const props = defineProps({
 	feeds: {
@@ -31,9 +32,10 @@ const errorMessage = ref('')
 
 const uuid = uuidFactory(props.url)
 const defineFeed = (): OptionsDatabase => {
+	const id = nanoid(10)
 	return {
-		id: uuid(),
-		slug: slug.value ?? uuid(),
+		id,
+		slug: slug.value ?? id,
 		title: title.value,
 		database: {
 			type: 'documents:redis',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4430,6 +4430,11 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+nanoid@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.6.tgz#7f99a033aa843e4dcf9778bdaec5eb02f4dc44d5"
+  integrity sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==
+
 nanostores@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/nanostores/-/nanostores-0.10.0.tgz#cb69d295aa8cd39874721388c452c74a22feb68f"


### PR DESCRIPTION
`feed.id` is just a configuration identifier and is not used as any DB key, so it can be accepted even it's a short, insecure string.