### PR TITLE
Add new plugin hook: onSetup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts",
-	"version": "0.15.3",
+	"version": "0.16.0",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/preview/src/plugin/edit:after:content-form.svelte
+++ b/preview/src/plugin/edit:after:content-form.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onUpdate } from '../../../src/plugin-helper'
+	import { onSetup, onUpdate } from '../../../src/plugin-helper'
 
 	onUpdate((post) => {
 		console.log('onUpdate', post)
@@ -8,6 +8,17 @@
 			options: [
 				...post.options.filter((o) => o.key !== 'x'),
 				{ key: 'x', value: 'this option was added by example-plugin.' },
+			],
+		}
+	})
+
+	onSetup((post) => {
+		console.log('onSetup', post)
+		return {
+			...post,
+			options: [
+				...post.options.filter((o) => o.key !== 'setup'),
+				{ key: 'setup', value: 'this option was added by example-plugin.' },
 			],
 		}
 	})

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -15,7 +15,10 @@ import { whenDefined, type UndefinedOr } from '@devprotocol/util-ts'
 import { emojiAllowList } from '../../constants'
 import { clientsProperty } from '@devprotocol/dev-kit'
 import EncodedPostData from '../../components/Common/EncodedPostData.vue'
-import { handleRegisterOnUpdateHandler } from '../../plugin-helper'
+import {
+	handleRegisterOnUpdateHandler,
+	handleRegisterOnSetupHandler,
+} from '../../plugin-helper'
 import { filterRequiredMemberships } from '../../fixtures/memberships'
 import { JsonRpcProvider } from 'ethers'
 
@@ -113,6 +116,10 @@ onMounted(async () => {
 	document.addEventListener(
 		Event.RegisterOnUpdateHandler,
 		handleRegisterOnUpdateHandler,
+	)
+	document.addEventListener(
+		Event.RegisterOnSetupHandler,
+		handleRegisterOnSetupHandler,
 	)
 	fetchPosts({})
 	const { connection: conct } = await import(

--- a/src/components/Page/Posts/Post/DoPost.vue
+++ b/src/components/Page/Posts/Post/DoPost.vue
@@ -6,7 +6,7 @@ import type { PostPrimitives, Posts } from '../../../../types'
 import { encode, decode } from '@devprotocol/clubs-core'
 import { whenDefined } from '@devprotocol/util-ts'
 import {
-	update as callUpdate,
+	setup as callSetup,
 	dispatchPostCreated,
 } from '../../../../plugin-helper'
 
@@ -27,19 +27,6 @@ const emit = defineEmits<Emits>()
 
 const onClickPost = async () => {
 	isPosting.value = true
-
-	const signer = (
-		await import('@devprotocol/clubs-core/connection')
-	).connection().signer.value
-	if (!signer) {
-		isPosting.value = false
-		return
-	}
-
-	const signerAddress = await signer.getAddress()
-
-	const hash = await keccak256(signerAddress)
-	const sig = await signer.signMessage(hash)
 
 	// 画像アップロード
 	const uploadedImageURLs: string[] = []
@@ -62,7 +49,20 @@ const onClickPost = async () => {
 			},
 		],
 	}
-	const newPost = await callUpdate(post)
+	const newPost = await callSetup(post)
+
+	const signer = (
+		await import('@devprotocol/clubs-core/connection')
+	).connection().signer.value
+	if (!signer) {
+		isPosting.value = false
+		return
+	}
+
+	const signerAddress = await signer.getAddress()
+
+	const hash = keccak256(signerAddress)
+	const sig = await signer.signMessage(hash)
 
 	// fetchで /message.jsonをpostしてasync/awaitでレスポンスを取得する
 	const response = await fetch(

--- a/src/plugin-helper/index.test.ts
+++ b/src/plugin-helper/index.test.ts
@@ -6,6 +6,11 @@ import {
 	onPostCreated,
 	onUpdate,
 	onUpdateHandlers,
+	update,
+	handleRegisterOnSetupHandler,
+	onSetup,
+	onSetupHandlers,
+	setup,
 } from '.'
 
 describe('onUpdate', () => {
@@ -26,6 +31,92 @@ describe('onUpdate', () => {
 		)
 		expect(val).toEqual(expected)
 	})
+
+	describe('update', () => {
+		it('should modify the post object by calling all the onUpdateHandlers', async () => {
+			onUpdateHandlers.clear()
+			const post = {
+				title: 'title',
+				content: 'content',
+				options: [],
+			}
+			document.addEventListener(
+				Event.RegisterOnUpdateHandler,
+				handleRegisterOnUpdateHandler,
+			)
+
+			onUpdate((post) => ({
+				...post,
+				options: [...post.options, { key: 'key1', value: 'value1' }],
+			}))
+			onUpdate(async (post) => ({
+				...post,
+				options: [...post.options, { key: 'key2', value: 'value2' }],
+			}))
+			const res = await update(post)
+			expect(res).toEqual({
+				title: 'title',
+				content: 'content',
+				options: [
+					{ key: 'key1', value: 'value1' },
+					{ key: 'key2', value: 'value2' },
+				],
+			})
+		})
+	})
+})
+
+describe('onSetup', () => {
+	it('should be calling CustomEvent with posts:event::register_on_setup_handler on document', () => {
+		const expected = async () => ({
+			title: 'title',
+			content: 'content',
+			options: [],
+		})
+		let val
+		document.addEventListener(Event.RegisterOnSetupHandler, async (e) => {
+			val = e.detail.handler
+		})
+		onSetup(expected)
+
+		expect(Event.RegisterOnSetupHandler).toBe(
+			'posts:event::register_on_setup_handler',
+		)
+		expect(val).toEqual(expected)
+	})
+
+	describe('setup', () => {
+		it('should modify the post object by calling all the onSeupHandlers', async () => {
+			onSetupHandlers.clear()
+			const post = {
+				title: 'title',
+				content: 'content',
+				options: [],
+			}
+			document.addEventListener(
+				Event.RegisterOnSetupHandler,
+				handleRegisterOnSetupHandler,
+			)
+
+			onSetup((post) => ({
+				...post,
+				options: [...post.options, { key: 'key1', value: 'value1' }],
+			}))
+			onSetup(async (post) => ({
+				...post,
+				options: [...post.options, { key: 'key2', value: 'value2' }],
+			}))
+			const res = await setup(post)
+			expect(res).toEqual({
+				title: 'title',
+				content: 'content',
+				options: [
+					{ key: 'key1', value: 'value1' },
+					{ key: 'key2', value: 'value2' },
+				],
+			})
+		})
+	})
 })
 
 describe('handleAddOnUpdateListener', () => {
@@ -42,6 +133,23 @@ describe('handleAddOnUpdateListener', () => {
 		onUpdate(expected)
 
 		expect(onUpdateHandlers.has(expected)).toBeTruthy()
+	})
+})
+
+describe('handleRegisterOnSeupHandler', () => {
+	it('should be adding handler function to onSetupHandlers', () => {
+		const expected = async () => ({
+			title: 'title',
+			content: 'content',
+			options: [],
+		})
+		document.addEventListener(
+			Event.RegisterOnSetupHandler,
+			handleRegisterOnSetupHandler,
+		)
+		onSetup(expected)
+
+		expect(onSetupHandlers.has(expected)).toBeTruthy()
 	})
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,4 +91,5 @@ export enum SlotName {
 export enum Event {
 	PostCreated = 'posts:event::post_created',
 	RegisterOnUpdateHandler = 'posts:event::register_on_update_handler',
+	RegisterOnSetupHandler = 'posts:event::register_on_setup_handler',
 }


### PR DESCRIPTION
- Add a new plugin hook: `onSetup`
- By calling onSetup, the handler function will be called when the user clicks the "Post" button and it's before API calling.

### Example
https://github.com/dev-protocol/clubs-plugin-posts/blob/98607e8f7424c8a12c3bee637cf12426b8d1e5fc/preview/src/plugin/edit:after:content-form.svelte#L15-L24