### PR TITLE
New slots for adding toolbar buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts",
-	"version": "0.16.2",
+	"version": "0.17.0",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts",
-	"version": "0.15.3",
+	"version": "0.16.0",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/preview/src/plugin/edit:after:content-form.svelte
+++ b/preview/src/plugin/edit:after:content-form.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onUpdate } from '../../../src/plugin-helper'
+	import { onSetup, onUpdate } from '../../../src/plugin-helper'
 
 	onUpdate((post) => {
 		console.log('onUpdate', post)
@@ -8,6 +8,17 @@
 			options: [
 				...post.options.filter((o) => o.key !== 'x'),
 				{ key: 'x', value: 'this option was added by example-plugin.' },
+			],
+		}
+	})
+
+	onSetup((post) => {
+		console.log('onSetup', post)
+		return {
+			...post,
+			options: [
+				...post.options.filter((o) => o.key !== 'setup'),
+				{ key: 'setup', value: 'this option was added by example-plugin.' },
 			],
 		}
 	})

--- a/preview/src/plugin/edit:after:content-form.svelte
+++ b/preview/src/plugin/edit:after:content-form.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import { onSetup, onUpdate } from '../../../src/plugin-helper'
+	import { onSetup, onUpdate, onClickToolbar } from '../../../src/plugin-helper'
+
+	let show = false
+
+	onClickToolbar('edit', () => {
+		show = !show
+	})
 
 	onUpdate((post) => {
 		console.log('onUpdate', post)
@@ -24,4 +30,6 @@
 	})
 </script>
 
-<div class="rounded bg-black/10 p-2">example-plugin added this slot</div>
+{#if show}
+	<div class="rounded bg-black/10 p-2">example-plugin added this slot</div>
+{/if}

--- a/preview/src/plugin/edit:toolbar:button.astro
+++ b/preview/src/plugin/edit:toolbar:button.astro
@@ -1,0 +1,5 @@
+---
+import Component from './edit:toolbar:button.svelte'
+---
+
+<Component client:load />

--- a/preview/src/plugin/edit:toolbar:button.svelte
+++ b/preview/src/plugin/edit:toolbar:button.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { onSetup, onUpdate } from '../../../src/plugin-helper'
+	import { emitClickToolbar } from '../../../src/plugin-helper'
 </script>
 
-<button
+<button on:click={() => emitClickToolbar('edit')}
 	><svg
 		xmlns="http://www.w3.org/2000/svg"
 		fill="none"

--- a/preview/src/plugin/edit:toolbar:button.svelte
+++ b/preview/src/plugin/edit:toolbar:button.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { onSetup, onUpdate } from '../../../src/plugin-helper'
+</script>
+
+<button
+	><svg
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 24 24"
+		stroke-width="2"
+		stroke="#117EFD"
+		class="w-6 h-6"
+	>
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"
+		/>
+	</svg>
+</button>

--- a/preview/src/plugin/index.ts
+++ b/preview/src/plugin/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@devprotocol/clubs-core'
 import AfterContentForm from './edit:after:content-form.astro'
 import AfterPostContent from './feed:after:post-content.astro'
+import EditToolbarButton from './edit:toolbar:button.astro'
 import { SlotName } from '../../../src'
 
 export const getSlots = (async () => [
@@ -16,6 +17,10 @@ export const getSlots = (async () => [
 	{
 		slot: SlotName.PostsFeedAfterPostContent,
 		component: AfterPostContent,
+	},
+	{
+		slot: SlotName.PostsEditToolbarButton,
+		component: EditToolbarButton,
 	},
 ]) satisfies ClubsFunctionGetSlots
 

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -15,7 +15,10 @@ import { whenDefined, type UndefinedOr } from '@devprotocol/util-ts'
 import { emojiAllowList } from '../../constants'
 import { clientsProperty } from '@devprotocol/dev-kit'
 import EncodedPostData from '../../components/Common/EncodedPostData.vue'
-import { handleRegisterOnUpdateHandler } from '../../plugin-helper'
+import {
+	handleRegisterOnUpdateHandler,
+	handleRegisterOnSetupHandler,
+} from '../../plugin-helper'
 import { filterRequiredMemberships } from '../../fixtures/memberships'
 import { JsonRpcProvider } from 'ethers'
 
@@ -113,6 +116,10 @@ onMounted(async () => {
 	document.addEventListener(
 		Event.RegisterOnUpdateHandler,
 		handleRegisterOnUpdateHandler,
+	)
+	document.addEventListener(
+		Event.RegisterOnSetupHandler,
+		handleRegisterOnSetupHandler,
 	)
 	fetchPosts({})
 	const { connection: conct } = await import(

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -164,6 +164,9 @@ const onPostDeleted = (id: string) => {
 				<template v-slot:after-content-form>
 					<slot name="edit:after:content-form" />
 				</template>
+				<template v-slot:toolbar-button>
+					<slot name="edit:toolbar:button" />
+				</template>
 			</Post>
 		</section>
 

--- a/src/components/Page/Posts/Post.vue
+++ b/src/components/Page/Posts/Post.vue
@@ -221,9 +221,10 @@ const handleDeleteImageAll = () => {
 		<Line class="" />
 		<!-- アクションエリア -->
 		<div class="flex items-center justify-between">
-			<!-- 画像ボタン -->
-			<AddMedia @upload:image="handleUploadImages" />
-			<!-- /画像ボタン -->
+			<div class="flex flex-wrap gap-3">
+				<AddMedia @upload:image="handleUploadImages" />
+				<slot name="toolbar-button"></slot>
+			</div>
 			<!-- Postボタン -->
 			<DoPost
 				:feedId="props.feedId"

--- a/src/components/Page/Posts/Post/DoPost.vue
+++ b/src/components/Page/Posts/Post/DoPost.vue
@@ -6,7 +6,7 @@ import type { PostPrimitives, Posts } from '../../../../types'
 import { encode, decode } from '@devprotocol/clubs-core'
 import { whenDefined } from '@devprotocol/util-ts'
 import {
-	update as callUpdate,
+	setup as callSetup,
 	dispatchPostCreated,
 } from '../../../../plugin-helper'
 
@@ -27,19 +27,6 @@ const emit = defineEmits<Emits>()
 
 const onClickPost = async () => {
 	isPosting.value = true
-
-	const signer = (
-		await import('@devprotocol/clubs-core/connection')
-	).connection().signer.value
-	if (!signer) {
-		isPosting.value = false
-		return
-	}
-
-	const signerAddress = await signer.getAddress()
-
-	const hash = await keccak256(signerAddress)
-	const sig = await signer.signMessage(hash)
 
 	// 画像アップロード
 	const uploadedImageURLs: string[] = []
@@ -62,7 +49,20 @@ const onClickPost = async () => {
 			},
 		],
 	}
-	const newPost = await callUpdate(post)
+	const newPost = await callSetup(post)
+
+	const signer = (
+		await import('@devprotocol/clubs-core/connection')
+	).connection().signer.value
+	if (!signer) {
+		isPosting.value = false
+		return
+	}
+
+	const signerAddress = await signer.getAddress()
+
+	const hash = keccak256(signerAddress)
+	const sig = await signer.signMessage(hash)
 
 	// fetchで /message.jsonをpostしてasync/awaitでレスポンスを取得する
 	const response = await fetch(

--- a/src/pages/Posts.astro
+++ b/src/pages/Posts.astro
@@ -32,6 +32,9 @@ const [, postId] = aperture(2, url.split('/')).find(([p]) => p === feedId) ?? []
 const SlotsPostsEditAfterContentForm = clubs.slots.filter(
 	(slot) => slot.slot === SlotName.PostsEditAfterContentForm,
 )
+const SlotsPostsEditToolbarButton = clubs.slots.filter(
+	(slot) => slot.slot === SlotName.PostsEditToolbarButton,
+)
 const SlotsPostsFeedAfterPostContent = clubs.slots.filter(
 	(slot) => slot.slot === SlotName.PostsFeedAfterPostContent,
 )
@@ -54,6 +57,15 @@ const SlotsPostsFeedAfterPostContent = clubs.slots.filter(
 				{...Slot.props}
 				feedId={feedId}
 				slot="edit:after:content-form"
+			/>
+		))
+	}
+	{
+		SlotsPostsEditToolbarButton.map((Slot) => (
+			<Slot.component
+				{...Slot.props}
+				feedId={feedId}
+				slot="edit:toolbar:button"
 			/>
 		))
 	}

--- a/src/plugin-helper/index.test.ts
+++ b/src/plugin-helper/index.test.ts
@@ -11,6 +11,8 @@ import {
 	onSetup,
 	onSetupHandlers,
 	setup,
+	onClickToolbar,
+	emitClickToolbar,
 } from '.'
 
 describe('onUpdate', () => {
@@ -187,5 +189,35 @@ describe('dispatchPostCreated', () => {
 
 		expect(Event.PostCreated).toBe('posts:event::post_created')
 		expect(val).toEqual(expected)
+	})
+})
+
+describe('onClickToolbar', () => {
+	it('should add handler to posts:event::click_toolbar event and the handler will be called when only `detail.key` is matched', () => {
+		let count = 0
+		onClickToolbar('key_xyz', () => {
+			count = count + 1
+		})
+		document.dispatchEvent(
+			new CustomEvent(Event.ClickToolbar, { detail: { key: 'key_xyz' } }),
+		)
+		document.dispatchEvent(
+			new CustomEvent(Event.ClickToolbar, { detail: { key: 'key_xyz_2' } }),
+		)
+
+		expect(Event.ClickToolbar).toBe('posts:event::click_toolbar')
+		expect(count).toBe(1)
+	})
+})
+
+describe('emitClickToolbar', () => {
+	it('should dispatch posts:event::click_toolbar event with `detail.key`', () => {
+		let count = 0
+		document.addEventListener(Event.ClickToolbar, () => {
+			count = count + 1
+		})
+		emitClickToolbar('key_xyz')
+
+		expect(count).toBe(1)
 	})
 })

--- a/src/plugin-helper/index.test.ts
+++ b/src/plugin-helper/index.test.ts
@@ -6,6 +6,11 @@ import {
 	onPostCreated,
 	onUpdate,
 	onUpdateHandlers,
+	update,
+	handleRegisterOnSetupHandler,
+	onSetup,
+	onSetupHandlers,
+	setup,
 } from '.'
 
 describe('onUpdate', () => {
@@ -26,6 +31,92 @@ describe('onUpdate', () => {
 		)
 		expect(val).toEqual(expected)
 	})
+
+	describe('update', () => {
+		it('should modify the post object by calling all the onUpdateHandlers', async () => {
+			onUpdateHandlers.clear()
+			const post = {
+				title: 'title',
+				content: 'content',
+				options: [],
+			}
+			document.addEventListener(
+				Event.RegisterOnUpdateHandler,
+				handleRegisterOnUpdateHandler,
+			)
+
+			onUpdate((post) => ({
+				...post,
+				options: [...post.options, { key: 'key1', value: 'value1' }],
+			}))
+			onUpdate(async (post) => ({
+				...post,
+				options: [...post.options, { key: 'key2', value: 'value2' }],
+			}))
+			const res = await update(post)
+			expect(res).toEqual({
+				title: 'title',
+				content: 'content',
+				options: [
+					{ key: 'key1', value: 'value1' },
+					{ key: 'key2', value: 'value2' },
+				],
+			})
+		})
+	})
+})
+
+describe('onSetup', () => {
+	it('should be calling CustomEvent with posts:event::register_on_setup_handler on document', () => {
+		const expected = async () => ({
+			title: 'title',
+			content: 'content',
+			options: [],
+		})
+		let val
+		document.addEventListener(Event.RegisterOnSetupHandler, async (e) => {
+			val = e.detail.handler
+		})
+		onSetup(expected)
+
+		expect(Event.RegisterOnSetupHandler).toBe(
+			'posts:event::register_on_setup_handler',
+		)
+		expect(val).toEqual(expected)
+	})
+
+	describe('setup', () => {
+		it('should modify the post object by calling all the onSeupHandlers', async () => {
+			onSetupHandlers.clear()
+			const post = {
+				title: 'title',
+				content: 'content',
+				options: [],
+			}
+			document.addEventListener(
+				Event.RegisterOnSetupHandler,
+				handleRegisterOnSetupHandler,
+			)
+
+			onSetup((post) => ({
+				...post,
+				options: [...post.options, { key: 'key1', value: 'value1' }],
+			}))
+			onSetup(async (post) => ({
+				...post,
+				options: [...post.options, { key: 'key2', value: 'value2' }],
+			}))
+			const res = await setup(post)
+			expect(res).toEqual({
+				title: 'title',
+				content: 'content',
+				options: [
+					{ key: 'key1', value: 'value1' },
+					{ key: 'key2', value: 'value2' },
+				],
+			})
+		})
+	})
 })
 
 describe('handleAddOnUpdateListener', () => {
@@ -42,6 +133,23 @@ describe('handleAddOnUpdateListener', () => {
 		onUpdate(expected)
 
 		expect(onUpdateHandlers.has(expected)).toBeTruthy()
+	})
+})
+
+describe('handleRegisterOnSeupHandler', () => {
+	it('should be adding handler function to onSetupHandlers', () => {
+		const expected = async () => ({
+			title: 'title',
+			content: 'content',
+			options: [],
+		})
+		document.addEventListener(
+			Event.RegisterOnSetupHandler,
+			handleRegisterOnSetupHandler,
+		)
+		onSetup(expected)
+
+		expect(onSetupHandlers.has(expected)).toBeTruthy()
 	})
 })
 

--- a/src/plugin-helper/index.ts
+++ b/src/plugin-helper/index.ts
@@ -25,6 +25,7 @@ export type EventRegisterOnSetupHandler = CustomEvent<{
 export type EventPostCreated = CustomEvent<{
 	readonly post: Posts
 }>
+export type EventClickToolbar = CustomEvent<{ readonly key: string }>
 
 export const onUpdateHandlers = new Set<OnUpdateHandler>()
 export const onSetupHandlers = new Set<OnSetupHandler>()
@@ -54,6 +55,19 @@ export const onSetup = (handler: OnSetupHandler) =>
 	typeof document !== 'undefined' &&
 	document.dispatchEvent(
 		new CustomEvent(Event.RegisterOnSetupHandler, { detail: { handler } }),
+	)
+export const onClickToolbar = (
+	key: string,
+	handler: (ev: EventClickToolbar) => unknown,
+) =>
+	typeof document !== 'undefined' &&
+	document.addEventListener(Event.ClickToolbar, (ev) => {
+		ev.detail.key === key && handler(ev)
+	})
+export const emitClickToolbar = (key: string) =>
+	typeof document !== 'undefined' &&
+	document.dispatchEvent(
+		new CustomEvent(Event.ClickToolbar, { detail: { key } }),
 	)
 
 const callHandlers = async (
@@ -109,7 +123,12 @@ export const onPostCreated = (handler: OnPostCreatedHandler) =>
 	typeof document !== 'undefined' &&
 	document.addEventListener(Event.PostCreated, (e) => handler(e.detail.post))
 
-const { PostCreated, RegisterOnUpdateHandler, RegisterOnSetupHandler } = Event
+const {
+	PostCreated,
+	RegisterOnUpdateHandler,
+	RegisterOnSetupHandler,
+	ClickToolbar,
+} = Event
 
 // eslint-disable-next-line functional/no-return-void
 export const dispatchPostCreated = (post: Posts) =>
@@ -123,5 +142,6 @@ declare global {
 		readonly [RegisterOnUpdateHandler]: EventRegisterOnUpdateHandler
 		readonly [PostCreated]: EventPostCreated
 		readonly [RegisterOnSetupHandler]: EventRegisterOnSetupHandler
+		readonly [ClickToolbar]: EventClickToolbar
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,10 +85,12 @@ export type Reactions = {
 
 export enum SlotName {
 	PostsEditAfterContentForm = 'posts:edit:after:content-form',
+	PostsEditToolbarButton = 'posts:edit:toolbar:button',
 	PostsFeedAfterPostContent = 'posts:feed:after:post-content',
 }
 
 export enum Event {
+	EventKey = 'posts:event::',
 	PostCreated = 'posts:event::post_created',
 	RegisterOnUpdateHandler = 'posts:event::register_on_update_handler',
 	RegisterOnSetupHandler = 'posts:event::register_on_setup_handler',

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,4 +91,5 @@ export enum SlotName {
 export enum Event {
 	PostCreated = 'posts:event::post_created',
 	RegisterOnUpdateHandler = 'posts:event::register_on_update_handler',
+	RegisterOnSetupHandler = 'posts:event::register_on_setup_handler',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,8 +90,8 @@ export enum SlotName {
 }
 
 export enum Event {
-	EventKey = 'posts:event::',
 	PostCreated = 'posts:event::post_created',
 	RegisterOnUpdateHandler = 'posts:event::register_on_update_handler',
 	RegisterOnSetupHandler = 'posts:event::register_on_setup_handler',
+	ClickToolbar = 'posts:event::click_toolbar',
 }


### PR DESCRIPTION
A new slot `PostsEditToolbarButton` allows plugins to extend toolbar buttons. An event utility function has also been added to control other slots via toolbar interactions.

![_localhost_3000_posts-2](https://github.com/dev-protocol/clubs-plugin-posts/assets/1970283/c2bdb66c-a2aa-4ead-86d4-e1c1e0f159f5)

## How to add a toolbar button

Define a component with `SlotName.PostsEditToolbarButton` as a slot with `getSlots`.

```ts
import { SlotName } from '@devprotocol/clubs-plugin-posts'
import Button from './Button.astro'

export const getSlots = async () => [
	{
		slot: SlotName.PostsEditToolbarButton,
		component: Button,
	},
]
```
Button.astro
```html
---
import Button from './Button.svelte'
---

<Button client:load />
```

## How to notify clicking to other components

`emitClickToolbar(key: string)` function dispatches the event, and calls listeners registered by `onClickToolbar` function. If the key to emit the event does not match the `onClickToolbar` key, nothing is called.

> [preview/src/plugin/edit:toolbar:button.svelte](https://github.com/dev-protocol/clubs-plugin-posts/blob/9824aea3ddfb1dcce3e50cc1233c6cf2fa296763/preview/src/plugin/edit:toolbar:button.svelte) and [preview/src/plugin/edit:after:content-form.svelte](https://github.com/dev-protocol/clubs-plugin-posts/blob/9824aea3ddfb1dcce3e50cc1233c6cf2fa296763/preview/src/plugin/edit:after:content-form.svelte) may serve as reference implementations.

```ts
import { emitClickToolbar } from '@devprotocol/clubs-plugin-posts/plugin-helper'

emitClickToolbar('foo-bar-baz')
```
```ts
import { onClickToolbar } from '@devprotocol/clubs-plugin-posts/plugin-helper'

onClickToolbar('foo-bar-baz', () => {
    // This handler is only executed when emitClickToolbar('foo-bar-baz') is called
})
```

### Example
Button.svelte
```svelte
<script lang="ts">
	import { emitClickToolbar } from '@devprotocol/clubs-plugin-posts/plugin-helper'
</script>

<button on:click={() => emitClickToolbar('edit-foo-bar')}
	><svg
		xmlns="http://www.w3.org/2000/svg"
		fill="none"
		viewBox="0 0 24 24"
		stroke-width="2"
		stroke="#117EFD"
		class="w-6 h-6"
	>
		<path
			stroke-linecap="round"
			stroke-linejoin="round"
			d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"
		/>
	</svg>
</button>
```

Example other component: Form.vue
```vue
<script lang="ts" setup>
	import { ref } from 'vue'
	import { onClickToolbar } from '@devprotocol/clubs-plugin-posts/plugin-helper'

	const show = ref(false)

	onClickToolbar('edit-foo-bar', () => {
		show.value = !show.value
	})
</script>

<template>
	<div v-if="show">The form ...</div>
</template>
```