### PR TITLE
Update type Option and refactor permissions in Index.vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@astrojs/svelte": "^5.0.0",
 		"@astrojs/tailwind": "^5.0.0",
 		"@astrojs/vue": "^4.0.0",
-		"@devprotocol/clubs-core": "3.10.0",
+		"@devprotocol/clubs-core": "3.10.1",
 		"@nanostores/vue": "^0.10.0",
 		"@redis/json": "^1.0.4",
 		"@rollup/plugin-typescript": "11.1.6",

--- a/preview/config.ts
+++ b/preview/config.ts
@@ -36,7 +36,7 @@ export default () =>
 		twitterHandle: '@debug',
 		description: '',
 		url: 'http://localhost:3000',
-		propertyAddress: '0xE8FCe1957bbaDb79C39E04dFf81782E892A22b9d',
+		propertyAddress: '0xE59fEDaBB0F79b0EC605737805a9125cd8d87B1f',
 		chainId: 80001,
 		rpcUrl: 'https://polygon-mumbai-bor.publicnode.com',
 		adminRolePoints: 0,
@@ -77,7 +77,7 @@ export default () =>
 								},
 								roles: {
 									write: {
-										memberships: [payloads[0]],
+										memberships: [payloads[0], payloads[1], payloads[2]], // You can post only if you have either Tier-1, Tier-2, or Tier-3.
 									},
 								},
 							},

--- a/preview/config.ts
+++ b/preview/config.ts
@@ -75,6 +75,11 @@ export default () =>
 										uuidv5('EXAMPLE_NAMESPACE', uuidv5.URL),
 									), // > 16be5315-0e57-5139-bba9-71d05675856b
 								},
+								roles: {
+									write: {
+										memberships: [payloads[0]],
+									},
+								},
 							},
 							{
 								id: 'default-3',

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -94,16 +94,20 @@ const writePermission = async (
 
 	const verifier = await membershipVerifier(requireMembership)
 
-	return verifier.result
+	return verifier ? verifier.result : false
 }
 
 const testPermission = async (
 	user: string,
 	provider: ContractRunner,
 ): Promise<boolean> => {
+	// check membership
 	const write = await writePermission(user, provider)
-	console.log('write:', write)
+	if (!write) {
+		return false
+	}
 
+	// check
 	const [a, b] = await clientsProperty(provider, props.propertyAddress)
 
 	const [balance, totalSupply] = await Promise.all([

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -58,9 +58,7 @@ const writePermission = async (
 	provider: ContractRunner,
 ): Promise<boolean> => {
 	const { roles } =
-		props.options
-			.find(({ key }) => key === 'posts')
-			?.value.find((option) => option.id === props.feedId) || {}
+		props.options[0].value.find((option) => option.id === props.feedId) || {}
 
 	return hasWritePermission({
 		account: user,
@@ -96,8 +94,7 @@ const testPermission = async (
 	provider: ContractRunner,
 ): Promise<boolean> => {
 	const membership = await writePermission(user, provider)
-	const admin =
-		membership === false ? await hasAdminRole(user, provider) : false
+	const admin = membership ? await hasAdminRole(user, provider) : false
 
 	return membership || admin
 }

--- a/src/components/Page/Index.vue
+++ b/src/components/Page/Index.vue
@@ -94,7 +94,8 @@ const testPermission = async (
 	provider: ContractRunner,
 ): Promise<boolean> => {
 	const membership = await writePermission(user, provider)
-	const admin = membership ? await hasAdminRole(user, provider) : false
+	const admin =
+		membership === false ? await hasAdminRole(user, provider) : false
 
 	return membership || admin
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,6 +283,8 @@ export const getApiPaths = (async (
 								config,
 								db.database.type,
 								db.database.key,
+								memberships ?? [],
+								db.roles,
 							),
 						},
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { ClubsGeneralUnit } from '@devprotocol/clubs-core'
 
 export type Option = {
 	readonly key: 'posts'
-	readonly value: readonly Posts[]
+	readonly value: readonly OptionsDatabase[]
 }
 
 export type TokenURIWithId = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,7 @@
-import type { ClubsGeneralUnit } from '@devprotocol/clubs-core'
+import type {
+	ClubsGeneralUnit,
+	Membership as MembershipCore,
+} from '@devprotocol/clubs-core'
 
 export type Option = {
 	readonly key: 'posts'
@@ -63,15 +66,7 @@ export type OptionsDatabase = {
 		  }
 }
 
-export type Membership = {
-	readonly id: string
-	readonly name: string
-	readonly description: string
-	readonly price: number
-	readonly currency: string
-	readonly imageSrc: string
-	readonly payload?: Uint8Array
-}
+export type Membership = MembershipCore
 
 /**
  * Reaction is a map of emoji to users who reacted to a post

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,10 +466,10 @@
   resolved "https://registry.yarnpkg.com/@boringer-avatars/vue3/-/vue3-0.2.1.tgz#db9d4183540de0d0af9e4e160cfc009f6f405e87"
   integrity sha512-KzAfh31SDXToTvFL0tBNG5Ur+VzfD1PP4jmY5/GS+eIuObGTIAiUu9eiht0LjuAGI+0xCgnaEgsTrOx8H3vLOQ==
 
-"@devprotocol/clubs-core@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-3.10.0.tgz#62966bc1f53e4eb2093bea0e64a6765cbd8dede9"
-  integrity sha512-E/0hFgL+uy/gzcPLVv3tp/q2foRRCPce7/8BhIcNxl7NrNOO9Ic1BNiS30oi9N6Myf62dK/6tt1pTzkhrSHE0g==
+"@devprotocol/clubs-core@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@devprotocol/clubs-core/-/clubs-core-3.10.1.tgz#e5b3ef6b817cd6c1051fcf285e052e79d99091b7"
+  integrity sha512-pZTJEWN0BYyFT+Jc19xS0ZfOuXml9VeyyEMoljFuT2d5h7T5DA5BIDe1Jdr69HbvT9otvSb/qh9YIhdhQIOJVw==
   dependencies:
     "@devprotocol/dev-kit" "8.6.0"
     "@devprotocol/elements" "1.1.0"
@@ -5590,7 +5590,7 @@ streamx@^2.13.0, streamx@^2.15.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5615,15 +5615,6 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -5667,7 +5658,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5687,13 +5678,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
The type Option has been altered to work with an OptionsDatabase array instead of Posts array in types.ts. In the Index.vue file, the handling of permissions has been thoroughly revamped to include a membership verifier factory, additional data extraction, and new inner functions within the lifecycle hook onMounted for managing roles, improving the overall function of membership permission checking and role handling within the application.