### PR TITLE
プロフィールコンポーネントをリファクタリング

### DIFF
--- a/src/components/Common/Profile.vue
+++ b/src/components/Common/Profile.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { ZeroAddress } from 'ethers'
-import { Avatar } from '@boringer-avatars/vue3'
 import type { ClubsProfile } from '@devprotocol/clubs-core'
 
 type Props = {
@@ -35,32 +34,22 @@ const truncateEthAddress = (address: string) => {
 	if (!match) return address
 	return `${match[1]}\u2026${match[2]}`
 }
+
+const PASSPORT_URL = `https://clubs.place/passport/${props.address}`
 </script>
 
 <template>
-	<div class="mb-2 flex w-8/12 items-center">
-		<template v-if="avatar">
-			<div
-				class="mr-3 h-12 w-12 rounded-full bg-cover bg-center bg-no-repeat"
-				:style="`background-image: url(${avatar})`"
-			/>
-		</template>
-		<template v-else>
-			<Avatar
-				class="mr-3"
-				:title="false"
-				:size="48"
-				variant="beam"
-				:name="props.address"
-				:square="false"
-			/>
-		</template>
+	<a :href="PASSPORT_URL" class="mb-2 flex w-8/12 items-center" target="_blank">
+		<div
+			class="mr-3 h-12 w-12 rounded-full bg-cover bg-center bg-no-repeat"
+			:style="`background-image: url(${avatar})`"
+		/>
 		<p
 			class="posts-username overflow-hidden overflow-ellipsis break-all text-base font-bold text-black"
 		>
 			{{ name }}
 		</p>
-	</div>
+	</a>
 </template>
 
 <style scoped>


### PR DESCRIPTION
`Profile.vue`のリファクタリングを行いました。Avatarのインポートとその使用方法を削除し、PASSPORT_URLでリンク付きのユーザー情報を表示するように変更しました。これにより、ユーザーはクリックするだけで自分のプロフィール情報を確認できます。