### PR TITLE
ロールとメンバーシップに基づいた投稿表示を制御

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts",
-	"version": "0.20.15",
+	"version": "0.20.16",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/src/apiHandler/posts.ts
+++ b/src/apiHandler/posts.ts
@@ -125,10 +125,12 @@ export const fetchPostHandler =
 		dbQueryKey,
 		config,
 		memberships,
+		roles,
 	}: {
 		readonly dbQueryKey: string
 		readonly config: ClubsConfiguration
 		readonly memberships: readonly Membership[]
+		readonly roles: OptionsDatabase['roles']
 	}) =>
 	async ({
 		request,
@@ -173,6 +175,7 @@ export const fetchPostHandler =
 					propertyAddress: config.propertyAddress,
 					rpcUrl: config.rpcUrl,
 					memberships: memberships,
+					roles: roles,
 				}),
 			)
 			const result = await whenNotErrorAll([post, mask], ([p, maskFn]) =>

--- a/src/apiHandler/search.ts
+++ b/src/apiHandler/search.ts
@@ -18,6 +18,7 @@ import { maskFactory } from '../fixtures/masking'
 import { headers } from '../fixtures/json'
 import { uuidToQuery } from '../fixtures/search'
 import type { OptionDocument } from '../db/redis-documents'
+import type { OptionsDatabase } from '../types.ts'
 
 const AVAILABLE_VALUE = /^[\w#-]+$/
 const normalize = (q: string) => q.replaceAll('-', ' ')
@@ -33,6 +34,7 @@ export const fetchPostHas =
 		dbQueryKey: string,
 		config: ClubsConfiguration,
 		memberships: readonly Membership[],
+		roles: OptionsDatabase['roles'],
 	): APIRoute =>
 	async ({ url }: { readonly request: Request; readonly url: URL }) => {
 		const pathquery = aperture(2, decodeURIComponent(url.pathname).split('/'))
@@ -98,6 +100,7 @@ export const fetchPostHas =
 				propertyAddress: config.propertyAddress,
 				rpcUrl: config.rpcUrl,
 				memberships,
+				roles,
 			}),
 		)
 

--- a/src/components/Page/Posts/Reactions.vue
+++ b/src/components/Page/Posts/Reactions.vue
@@ -95,7 +95,7 @@ const addReaction = async ({
 
 	if (res.status === 200) {
 		const emojiReactions = reactions.value[emoji] ?? []
-		console.log('emoji reactions are: ', emojiReactions)
+		// console.log('emoji reactions are: ', emojiReactions)
 		reactions.value = {
 			...reactions.value,
 			[emoji]: [...emojiReactions, { createdBy: userAddress, id }],

--- a/src/db/redis.ts
+++ b/src/db/redis.ts
@@ -192,7 +192,7 @@ export const fetchSinglePost = async ({
 				postId: post.id,
 				client,
 			})
-			console.log('reactions are: ', reactions)
+			// console.log('reactions are: ', reactions)
 			const groupCreatedBy = (
 				acc: readonly {
 					readonly createdBy: string
@@ -202,7 +202,7 @@ export const fetchSinglePost = async ({
 			) => acc.concat([{ createdBy: created_by, id }])
 			const toEmoji = ({ content }: ReactionDocument) => content
 			const reduced = reduceBy(groupCreatedBy, [], toEmoji, reactions)
-			console.log('reduced are: ', reduced)
+			// console.log('reduced are: ', reduced)
 			return reduced
 		},
 	)

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,7 @@ export const getApiPaths = (async (
 										propertyAddress: config.propertyAddress,
 										rpcUrl: config.rpcUrl,
 										memberships: memberships ?? [],
+										roles: db.roles,
 									})
 									// eslint-disable-next-line
 									allPosts =
@@ -409,6 +410,7 @@ export const getApiPaths = (async (
 								dbQueryKey: db.database.key,
 								config,
 								memberships: memberships ?? [],
+								roles: db.roles,
 							}),
 						},
 						/**
@@ -447,7 +449,12 @@ export const getApiPaths = (async (
 				({
 					paths: [db.id, 'search', /.*/],
 					method: 'GET',
-					handler: fetchPostHas(db.database.key, config, memberships ?? []),
+					handler: fetchPostHas(
+						db.database.key,
+						config,
+						memberships ?? [],
+						db.roles,
+					),
 				}) satisfies ClubsApiPath,
 		),
 	]


### PR DESCRIPTION
特定のロールとメンバーシップによる投稿表示制御のために、APIハンドラとDBコードを修正しました。ロール情報をAPIハンドラに渡し、各投稿の読み書き権限を検証します。不要なコンソールログも削除しました。